### PR TITLE
Add PlatformIO support, Fix DRAM problem and Add guide for beginners

### DIFF
--- a/ESP32_LogicAnalyzer.h
+++ b/ESP32_LogicAnalyzer.h
@@ -51,11 +51,13 @@
 
 #endif
 
+#ifdef DEBUG
 unsigned int time_debug_indice_dma[1024];
 unsigned int time_debug_indice_dma_p=0;
 
 unsigned int time_debug_indice_rle[1024];
 unsigned int time_debug_indice_rle_p=0;
+#endif
 
 int stop_at_desc=-1;
 unsigned int logicIndex = 0;
@@ -220,6 +222,8 @@ bool rle_init(void){
   rle_buff_end = rle_buff+rle_size-4;
 
   memset( rle_buff, 0x00, rle_size);
+  
+  return true;
 }
 
 void dma_serializer( dma_elem_t *dma_buffer ){
@@ -390,7 +394,9 @@ void fast_rle_block_encode_asm_8bit_ch1(uint8_t *dma_buffer, int sample_size){ /
 
       
     clockb = xthal_get_ccount();
+#ifdef DEBUG
     time_debug_indice_rle[time_debug_indice_rle_p++]=clockb;
+#endif
  //   Serial_Debug_Port.printf("\r\n asm_process takes %d clocks\r\n",(clockb-clocka));
  //   Serial_Debug_Port.printf( "RX  Buffer = %d bytes\r\n", sample_size );
  //   Serial_Debug_Port.printf( "RLE Buffer = %d bytes\r\n", (rle_buff_p - rle_buff) );
@@ -559,7 +565,9 @@ void fast_rle_block_encode_asm_8bit_ch2(uint8_t *dma_buffer, int sample_size){ /
 
       
     clockb = xthal_get_ccount();
+#ifdef DEBUG
     time_debug_indice_rle[time_debug_indice_rle_p++]=clockb;
+#endif
  //   Serial_Debug_Port.printf("\r\n asm_process takes %d clocks\r\n",(clockb-clocka));
  //   Serial_Debug_Port.printf( "RX  Buffer = %d bytes\r\n", sample_size );
  //   Serial_Debug_Port.printf( "RLE Buffer = %d bytes\r\n", (rle_buff_p - rle_buff) );
@@ -692,7 +700,9 @@ void fast_rle_block_encode_asm_16bit(uint8_t *dma_buffer, int sample_size){ //si
       :"a"(&dma_buffer), "a"(dword_count), "a"(&rle_buff_p):
       "a4","a5","a6","a7","a8","a9","a10","a11","memory");
     clockb = xthal_get_ccount();
+#ifdef DEBUG
     time_debug_indice_rle[time_debug_indice_rle_p++]=clockb;
+#endif
 
 //    delay(10);
 

--- a/ESP32_LogicAnalyzer.ino
+++ b/ESP32_LogicAnalyzer.ino
@@ -285,6 +285,7 @@ void captureMilli() {
   Serial_Debug_Port.printf("used_desc = %d\r\n", filled_desc);
   Serial_Debug_Port.printf("used_sample_offset = %d\r\n", filled_sample_offset);
 
+#ifdef DEBUG
   Serial_Debug_Port.printf( "\r\nDMA Times:" );
   for(int i = 0 ; i <  50 ; i++){
     Serial_Debug_Port.printf( "%u\t", time_debug_indice_dma[i]-time_debug_indice_dma[0] );
@@ -294,6 +295,8 @@ void captureMilli() {
   for(int i = 0 ; i <  50 ; i++){
     Serial_Debug_Port.printf( "%u\t", time_debug_indice_rle[i]-time_debug_indice_dma[0] );
     }
+#endif
+
   Serial_Debug_Port.printf( "\r\nDone\r\n" );
   Serial_Debug_Port.flush();
   filled_desc--;

--- a/ESP32_LogicAnalyzer_I2S_DMA.ino
+++ b/ESP32_LogicAnalyzer_I2S_DMA.ino
@@ -9,10 +9,12 @@ void start_dma_capture(void) {
   s_state->dma_filtered_count = 0;
   s_state->dma_desc_triggered = 0;
 
+#ifdef DEBUG
 time_debug_indice_dma_p=0;
 time_debug_indice_rle_p=0;
 for(int i=0; i < 1024 ; i++ )
 time_debug_indice_dma[i]=time_debug_indice_rle[i]=0;
+#endif
 
   ESP_ERROR_CHECK(esp_intr_disable(s_state->i2s_intr_handle));
   i2s_conf_reset();
@@ -92,7 +94,9 @@ static void IRAM_ATTR i2s_isr(void* arg) {
   //gpio_set_level(, 1); //Should show a pulse on the logic analyzer when an interrupt occurs
   //gpio_set_level(, 0);
   if(I2S0.int_raw.in_done){ //filled desc
+#ifdef DEBUG
     time_debug_indice_dma[time_debug_indice_dma_p++]=xthal_get_ccount();
+#endif
     
     //Serial_Debug_Port.printf("DMA INT Number %d Status 0x%xX\r\n", s_state->dma_desc_cur, I2S0.int_raw.val);
     

--- a/README.md
+++ b/README.md
@@ -57,9 +57,11 @@ This project steals some code from [esp32-cam-demo](https://github.com/igrr/esp3
     #endif
     ```
 3. Build the project and flash with PlatformIO
-4. After the firmware is uploaded, open PulseView, follow the settings in the figure
+4. Connect PIN15 to GND (This is to disable boot messages, or PulseView cannot detect this device, probably related to [this issue](https://github.com/EUA/ESP32_LogicAnalyzer/issues/1#issuecomment-582195593))
+5. After PIN15 is connected to GND, open PulseView, follow the settings in the figure
   ![image](https://github.com/CW-B-W/ESP32_LogicAnalyzer/assets/76680670/b571412e-4b85-43b3-980c-3df5d2544d7c)
-5. Make sure the # of samples is at least 2K samples (or ESP32 will not respond), and run.
+6. Make sure the # of samples is at least 2K samples (or ESP32 will not respond), and run.
+  ![image](https://github.com/CW-B-W/ESP32_LogicAnalyzer/assets/76680670/b26a0c52-d383-46fc-9278-f6ccbfa038ed)
 
 ## PulseView Channel -> ESP32 PIN
 

--- a/README.md
+++ b/README.md
@@ -27,3 +27,60 @@ If you like it, why not to say thanks or support via [Patreon](https://www.patre
 
 
 This project steals some code from [esp32-cam-demo](https://github.com/igrr/esp32-cam-demo) for I2S DMA and [Arduino Logic Analyzer](https://github.com/gillham/logic_analyzer) as SUMP protocol "template".
+
+
+## Quick start guide
+1. Use PlatformIO (in VS Code) to open the project folder
+2. Modify to use UART0 (MicroUSB) to communicate with PulseView
+  * In `ESP32_LogicAnalyzer.h`, set `USE_SERIAL2_FOR_OLS` to 0
+    ```C++
+    #define USE_SERIAL2_FOR_OLS 0 // If 1, UART2 = OLS and UART0=Debug
+    ```
+  * In `ESP32_LogicAnalyzer.h`, set `OLS_Port_Baud` to 115200, in case that the ESP32 dev board cannot support 921600
+    ```C++
+    #if USE_SERIAL2_FOR_OLS
+
+    #define Serial_Debug_Port Serial
+    //#define Serial_Debug_Port_Baud 115200
+    #define Serial_Debug_Port_Baud 921600
+    //#define Serial_Debug_Port_Baud 1000000
+    #define OLS_Port Serial2
+    #define OLS_Port_Baud 3000000
+    
+    #else
+    
+    #define Serial_Debug_Port Serial2
+    #define Serial_Debug_Port_Baud 115200
+    #define OLS_Port Serial
+    #define OLS_Port_Baud 115200
+    
+    #endif
+    ```
+3. Build the project and flash with PlatformIO
+4. After the firmware is uploaded, open PulseView, follow the settings in the figure
+  ![image](https://github.com/CW-B-W/ESP32_LogicAnalyzer/assets/76680670/b571412e-4b85-43b3-980c-3df5d2544d7c)
+5. Make sure the # of samples is at least 2K samples (or ESP32 will not respond), and run.
+
+## PulseView Channel -> ESP32 PIN
+
+| Channel | PIN   |
+| :-----  | ----: |
+| 0 | 0  |
+| 1 | 18 |
+| 2 | 2  |
+| 3 | 19 |
+| 4 | 4  |
+| 5 | 5 |
+| 11 | 22 |
+| 12 | 12 |
+| 13 | 13 |
+| 14 | 14 |
+| 15 | 15 |
+
+This can be found in the [source code](https://github.com/EUA/ESP32_LogicAnalyzer/blob/5880dabeb22ce99df7cebdd727fe66dabf98d8e3/ESP32_LogicAnalyzer.ino#L45-L61)
+```C++
+cfg.gpio_bus[0] = 0;
+cfg.gpio_bus[1] = 18; //GPIO01 used for UART 0 RX
+.
+.
+```

--- a/platformio.ini
+++ b/platformio.ini
@@ -1,0 +1,19 @@
+; PlatformIO Project Configuration File
+;
+;   Build options: build flags, source filter
+;   Upload options: custom upload port, speed and extra flags
+;   Library options: dependencies, extra library storages
+;   Advanced options: extra scripting
+;
+; Please visit documentation for the other options and examples
+; https://docs.platformio.org/page/projectconf.html
+
+[platformio]
+src_dir = .
+
+[env:esp32dev]
+; platform = espressif32
+platform = espressif32@4.0          ; Lastest espressif32 fails to be scanned by PulseView
+board = esp32dev
+framework = arduino
+build_flags = -DCORE_DEBUG_LEVEL=0  ; Disable UART0 logging


### PR DESCRIPTION
Thanks for this awesome project.

In this PR,

* Add PlatformIO support for better convenience
    * And force to use espressif32@4.0. This project seems to have problem with the latest espressif32 platform
* Resolve "section .dram0.bss will not fit" problem by not compile unnecessary debugging parts
* Write a Quick Start Guide for beginners